### PR TITLE
Fixes #5 - add correct regex for default hostgroup plugin

### DIFF
--- a/deploy/vagrant-oscar/files/foreman/default_hostgroup.yaml
+++ b/deploy/vagrant-oscar/files/foreman/default_hostgroup.yaml
@@ -2,4 +2,4 @@
 :default_hostgroup:
   :facts_map:
     "OpsTheater Infra":
-      "hostname": "*"
+      "hostname": ".*"


### PR DESCRIPTION
This is to fix the issue where new hosts are not added to the OpsTheather Infra hostgroup on TheForeman dashboard.