### PR TITLE
Adding firewall rules for opstheater services

### DIFF
--- a/hieradata/60.opstheater.yaml
+++ b/hieradata/60.opstheater.yaml
@@ -22,7 +22,7 @@
 
 # Enable firewall rules
 # Default value: false
-'opstheater::manage_firewall': false
+'opstheater::manage_firewall': true
 
 # Purge unmanaged firewall rules
 # Default value: true
@@ -41,6 +41,9 @@
   - "%{hiera('opstheater::elasticsearch::ipaddress')}"
   - "%{hiera('opstheater::gitlab::ipaddress')}"
   - "%{hiera('opstheater::foreman::ipaddress')}"
+  - "%{hiera('opstheater::mattermost::ipaddress')}"
+  - "%{hiera('opstheater::kibana::ipaddress')}"
+  - "%{hiera('opstheater::puppet::ipaddress')}"
 
 # IP address for VPN or internal network to access opstheater dashboards
 # Default value: 0.0.0.0
@@ -70,7 +73,8 @@
 ##########################
 'opstheater::foreman::fqdn': "master.%{hiera('opstheater::domain')}"
 'opstheater::foreman::url': "%{hiera('opstheater::http_mode')}://%{hiera('opstheater::foreman::fqdn')}"
-'opstheater::foreman::ipaddress': '10.20.1.10'
+'opstheater::foreman::ipaddress': "%{hiera('opstheater::puppet::ipaddress')}"
+'opstheater::puppet::ipaddress': '10.20.1.10'
 
 
 ##########################

--- a/hieradata/60.opstheater.yaml
+++ b/hieradata/60.opstheater.yaml
@@ -32,6 +32,16 @@
 # Default value: true
 'opstheater::purge_firewallchains': true
 
+# IPs to be whitelisted in the opstheater chain in an array.
+# Append all the new IPs in this array. Do not remove existing ones
+# Default value: [ ]
+'opstheater::ip_whitelist':
+  - "%{hiera('opstheater::icinga::ipaddress')}"
+  - "%{hiera('opstheater::mysql::ipaddress')}"
+  - "%{hiera('opstheater::elasticsearch::ipaddress')}"
+  - "%{hiera('opstheater::gitlab::ipaddress')}"
+  - "%{hiera('opstheater::foreman::ipaddress')}"
+
 # IP address for VPN or internal network to access opstheater dashboards
 # Default value: 0.0.0.0
 'opstheater::vpn_ip': '0.0.0.0'
@@ -60,6 +70,7 @@
 ##########################
 'opstheater::foreman::fqdn': "master.%{hiera('opstheater::domain')}"
 'opstheater::foreman::url': "%{hiera('opstheater::http_mode')}://%{hiera('opstheater::foreman::fqdn')}"
+'opstheater::foreman::ipaddress': '10.20.1.10'
 
 
 ##########################

--- a/hieradata/60.opstheater.yaml
+++ b/hieradata/60.opstheater.yaml
@@ -15,6 +15,23 @@
 # Default value (for production): 'https'
 'opstheater::http_mode': 'https'
 
+
+#########################
+## Firewall settings
+########################
+
+# Enable firewall rules
+# Default value: false
+'opstheater::manage_firewall': false
+
+# Purge unmanaged firewall rules
+# Default value: true
+'opstheater::purge_firewalls': true
+
+# Purge unmanaged firewall chains
+# Default value: true
+'opstheater::purge_firewallchains': true
+
 # SMTP Settings
 # FQDN of SMTP server (eg: smtp.gmail.com)
 'opstheater::smtp::fqdn': 'localhost'

--- a/hieradata/60.opstheater.yaml
+++ b/hieradata/60.opstheater.yaml
@@ -32,6 +32,10 @@
 # Default value: true
 'opstheater::purge_firewallchains': true
 
+# IP address for VPN or internal network to access opstheater dashboards
+# Default value: 0.0.0.0
+'opstheater::vpn_ip': '0.0.0.0'
+
 # SMTP Settings
 # FQDN of SMTP server (eg: smtp.gmail.com)
 'opstheater::smtp::fqdn': 'localhost'

--- a/site/opstheater/manifests/profile/base.pp
+++ b/site/opstheater/manifests/profile/base.pp
@@ -14,6 +14,12 @@ class opstheater::profile::base {
   include ::ssh::client
   include ::ssh::server
 
+  # manage iptables rules
+  $manage_firewall = hiera('opstheater::manage_firewall', undef)
+  if $manage_firewall {
+    include opstheater::profile::firewall
+  }
+
   # configure filebeat
   include opstheater::profile::base::filebeat
 

--- a/site/opstheater/manifests/profile/base.pp
+++ b/site/opstheater/manifests/profile/base.pp
@@ -11,8 +11,7 @@ class opstheater::profile::base {
   }
 
   # configure ssh
-  include ::ssh::client
-  include ::ssh::server
+  include opstheater::profile::ssh
 
   # manage iptables rules
   $manage_firewall = hiera('opstheater::manage_firewall', undef)

--- a/site/opstheater/manifests/profile/elasticsearch.pp
+++ b/site/opstheater/manifests/profile/elasticsearch.pp
@@ -16,5 +16,21 @@ class opstheater::profile::elasticsearch{
   } else {
     fail("No elasticsearch instances found in hiera for class opstheater::profile::elasticsearch on ${::fqdn}.")
   }
-    
+
+  @firewall { '200 allow elasticsearch 9200 access':
+    chain   => 'INPUT',
+    jump    => 'OPSTHEATER',
+    proto   => 'tcp',
+    dport   => '9200',
+    tag     => 'opstheater',
+  }
+ 
+  @firewall { '200 allow elasticsearch 9300 access':
+    chain   => 'INPUT',
+    jump    => 'OPSTHEATER',
+    proto   => 'tcp',
+    dport   => '9300',
+    tag     => 'opstheater',
+  }
+ 
 }

--- a/site/opstheater/manifests/profile/elasticsearch.pp
+++ b/site/opstheater/manifests/profile/elasticsearch.pp
@@ -18,19 +18,19 @@ class opstheater::profile::elasticsearch{
   }
 
   @firewall { '200 allow elasticsearch 9200 access':
-    chain   => 'INPUT',
-    jump    => 'OPSTHEATER',
-    proto   => 'tcp',
-    dport   => '9200',
-    tag     => 'opstheater',
+    chain => 'INPUT',
+    jump  => 'OPSTHEATER',
+    proto => 'tcp',
+    dport => '9200',
+    tag   => 'opstheater',
   }
  
   @firewall { '200 allow elasticsearch 9300 access':
-    chain   => 'INPUT',
-    jump    => 'OPSTHEATER',
-    proto   => 'tcp',
-    dport   => '9300',
-    tag     => 'opstheater',
+    chain => 'INPUT',
+    jump  => 'OPSTHEATER',
+    proto => 'tcp',
+    dport => '9300',
+    tag   => 'opstheater',
   }
  
 }

--- a/site/opstheater/manifests/profile/firewall.pp
+++ b/site/opstheater/manifests/profile/firewall.pp
@@ -17,16 +17,16 @@ class opstheater::profile::firewall {
   }
 
   firewallchain { 'OPSTHEATER:filter:IPv4':
-    ensure  => present,
-    purge   => true,
+    ensure => present,
+    purge  => true,
   }
 
   $ip_whitelist.each | String $ip | {
     firewall { "100 accept connections for ${ip}":
-      chain   => 'OPSTHEATER',
-      action  => 'accept'
-      proto   => 'all',
-      source  => $ip,
+      chain  => 'OPSTHEATER',
+      action => 'accept'
+      proto  => 'all',
+      source => $ip,
     }
   }
 

--- a/site/opstheater/manifests/profile/firewall.pp
+++ b/site/opstheater/manifests/profile/firewall.pp
@@ -21,7 +21,8 @@ class opstheater::profile::firewall {
     purge  => true,
   }
 
-  $ip_whitelist.each | String $ip | {
+  $ip_list = unique($ip_whitelist)
+  $ip_list.each | String $ip | {
     firewall { "100 accept connections for ${ip}":
       chain  => 'OPSTHEATER',
       action => 'accept'

--- a/site/opstheater/manifests/profile/firewall.pp
+++ b/site/opstheater/manifests/profile/firewall.pp
@@ -2,7 +2,7 @@ class opstheater::profile::firewall {
 
   $purge_firewalls = hiera('opstheater::purge_firewalls', true)
   $purge_firewallchains = hiera('opstheater::purge_firewallchains', true)
-  $ip_whitelist = hiera('opstheater::ip_whiteliste', undef)
+  $ip_whitelist = hiera('opstheater::ip_whitelist', undef)
 
   include ::firewall
   include ::opstheater::profile::firewall::pre

--- a/site/opstheater/manifests/profile/firewall.pp
+++ b/site/opstheater/manifests/profile/firewall.pp
@@ -1,0 +1,40 @@
+class opstheater::profile::firewall {
+
+  $purge_firewalls = hiera('opstheater::purge_firewalls', true)
+  $purge_firewallchains = hiera('opstheater::purge_firewallchains', true)
+  $ip_whitelist = hiera('opstheater::ip_whiteliste', undef)
+
+  include ::firewall
+  include ::opstheater::profile::firewall::pre
+  include ::opstheater::profile::firewall::post
+
+  resources { 'firewall':
+    purge => $purge_firewalls,
+  }
+
+  resources { 'firewallchain':
+    purge => $purge_firewallchains,
+  }
+
+  firewallchain { 'OPSTHEATER:filter:IPv4':
+    ensure  => present,
+    purge   => true,
+  }
+
+  $ip_whitelist.each | String $ip | {
+    firewall { "100 accept connections for ${ip}":
+      chain   => 'OPSTHEATER',
+      action  => 'accept'
+      proto   => 'all',
+      source  => $ip,
+    }
+  }
+
+  Firewall <| tag == 'opstheater' |>
+
+  Firewall {
+    before  => Class['opstheater::profile::firewall::pre']
+    require => Class['opstheater::profile::firewall::post']
+  }
+
+}

--- a/site/opstheater/manifests/profile/firewall/post.pp
+++ b/site/opstheater/manifests/profile/firewall/post.pp
@@ -1,4 +1,4 @@
-class opstheather::profile::firewall::post {
+class opstheater::profile::firewall::post {
 
   firewall { '999 drop all':
     proto  => 'all',

--- a/site/opstheater/manifests/profile/firewall/post.pp
+++ b/site/opstheater/manifests/profile/firewall/post.pp
@@ -1,0 +1,9 @@
+class opstheather::profile::firewall::post {
+
+  firewall { '999 drop all':
+    proto  => 'all',
+    action => 'drop',
+    before => undef,
+  }
+
+}

--- a/site/opstheater/manifests/profile/firewall/pre.pp
+++ b/site/opstheater/manifests/profile/firewall/pre.pp
@@ -1,0 +1,32 @@
+class opstheater::profile::firewall::pre {
+
+  Firewall {
+    require => undef,
+  }
+
+   # Default firewall rules
+  firewall { '000 accept all icmp':
+    proto  => 'icmp',
+    action => 'accept',
+  }->
+
+  firewall { '001 accept all to lo interface':
+    proto   => 'all',
+    iniface => 'lo',
+    action  => 'accept',
+  }->
+
+  firewall { '002 reject local traffic not on loopback interface':
+    iniface     => '! lo',
+    proto       => 'all',
+    destination => '127.0.0.1/8',
+    action      => 'reject',
+  }->
+
+  firewall { '003 accept related established rules':
+    proto  => 'all',
+    state  => ['RELATED', 'ESTABLISHED'],
+    action => 'accept',
+  }
+
+}

--- a/site/opstheater/manifests/profile/foremanproxy.pp
+++ b/site/opstheater/manifests/profile/foremanproxy.pp
@@ -81,4 +81,23 @@ class opstheater::profile::foremanproxy {
       proxy       => 'http://localhost:3000/',
     }
   }
+
+  @firewall { '203 allow HTTP access to foreman':
+    chain   => 'INPUT',
+    action  => 'accept',
+    proto   => 'tcp',
+    dport   => '80',
+    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag     => 'opstheater',
+  }
+
+  @firewall { '204 allow HTTPS access to foreman':
+    chain   => 'INPUT',
+    action  => 'accept',
+    proto   => 'tcp',
+    dport   => '443',
+    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag     => 'opstheater',
+  }
+
 }

--- a/site/opstheater/manifests/profile/foremanproxy.pp
+++ b/site/opstheater/manifests/profile/foremanproxy.pp
@@ -83,21 +83,21 @@ class opstheater::profile::foremanproxy {
   }
 
   @firewall { '203 allow HTTP access to foreman':
-    chain   => 'INPUT',
-    action  => 'accept',
-    proto   => 'tcp',
-    dport   => '80',
-    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
-    tag     => 'opstheater',
+    chain  => 'INPUT',
+    action => 'accept',
+    proto  => 'tcp',
+    dport  => '80',
+    source => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag    => 'opstheater',
   }
 
   @firewall { '204 allow HTTPS access to foreman':
-    chain   => 'INPUT',
-    action  => 'accept',
-    proto   => 'tcp',
-    dport   => '443',
-    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
-    tag     => 'opstheater',
+    chain  => 'INPUT',
+    action => 'accept',
+    proto  => 'tcp',
+    dport  => '443',
+    source => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag    => 'opstheater',
   }
 
 }

--- a/site/opstheater/manifests/profile/gitlab.pp
+++ b/site/opstheater/manifests/profile/gitlab.pp
@@ -180,4 +180,22 @@ class opstheater::profile::gitlab {
   include opstheater::profile::filebeat::gitlab
   include opstheater::profile::filebeat::mattermost
 
+  @firewall { '205 allow HTTP access to gitlab':
+    chain   => 'INPUT',
+    action  => 'accept',
+    proto   => 'tcp',
+    dport   => '80',
+    source  => hiera('opstheater::vpn_ip', '0.0.0.0')
+    tag     => 'opstheater',
+  }
+
+  @firewall { '206 allow HTTPS access to gitlab':
+    chain   => 'INPUT',
+    jump    => 'OPSTHEATER',
+    proto   => 'tcp',
+    dport   => '443',
+    source  => hiera('opstheater::vpn_ip', '0.0.0.0')
+    tag     => 'opstheater',
+  } 
+
 }

--- a/site/opstheater/manifests/profile/gitlab.pp
+++ b/site/opstheater/manifests/profile/gitlab.pp
@@ -181,21 +181,21 @@ class opstheater::profile::gitlab {
   include opstheater::profile::filebeat::mattermost
 
   @firewall { '205 allow HTTP access to gitlab':
-    chain   => 'INPUT',
-    action  => 'accept',
-    proto   => 'tcp',
-    dport   => '80',
-    source  => hiera('opstheater::vpn_ip', '0.0.0.0')
-    tag     => 'opstheater',
+    chain  => 'INPUT',
+    action => 'accept',
+    proto  => 'tcp',
+    dport  => '80',
+    source => hiera('opstheater::vpn_ip', '0.0.0.0')
+    tag    => 'opstheater',
   }
 
   @firewall { '206 allow HTTPS access to gitlab':
-    chain   => 'INPUT',
-    jump    => 'OPSTHEATER',
-    proto   => 'tcp',
-    dport   => '443',
-    source  => hiera('opstheater::vpn_ip', '0.0.0.0')
-    tag     => 'opstheater',
-  } 
+    chain  => 'INPUT',
+    jump   => 'OPSTHEATER',
+    proto  => 'tcp',
+    dport  => '443',
+    source => hiera('opstheater::vpn_ip', '0.0.0.0')
+    tag    => 'opstheater',
+  }
 
 }

--- a/site/opstheater/manifests/profile/grafana.pp
+++ b/site/opstheater/manifests/profile/grafana.pp
@@ -47,4 +47,13 @@ class opstheater::profile::grafana {
     },
   }
 
+  @firewall { '207 allow HTTP access to grafana':
+    chain   => 'INPUT',
+    action  => 'accept',
+    proto   => 'tcp',
+    dport   => '3000',
+    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag     => 'opstheater',
+  }
+
 }

--- a/site/opstheater/manifests/profile/grafana.pp
+++ b/site/opstheater/manifests/profile/grafana.pp
@@ -48,12 +48,12 @@ class opstheater::profile::grafana {
   }
 
   @firewall { '207 allow HTTP access to grafana':
-    chain   => 'INPUT',
-    action  => 'accept',
-    proto   => 'tcp',
-    dport   => '3000',
-    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
-    tag     => 'opstheater',
+    chain  => 'INPUT',
+    action => 'accept',
+    proto  => 'tcp',
+    dport  => '3000',
+    source => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag    => 'opstheater',
   }
 
 }

--- a/site/opstheater/manifests/profile/icinga/client.pp
+++ b/site/opstheater/manifests/profile/icinga/client.pp
@@ -38,4 +38,12 @@ class opstheater::profile::icinga::client {
 
   Icinga2::Object::Zone <<| |>>
 
+  @firewall { '201 allow access to icinga client':
+    chain => 'INPUT',
+    jump  => 'OPSTHEATER',
+    proto => 'tcp',
+    dport => '5665',
+    tag   => 'opstheater',
+  }
+
 }

--- a/site/opstheater/manifests/profile/icinga/server.pp
+++ b/site/opstheater/manifests/profile/icinga/server.pp
@@ -42,4 +42,12 @@ class opstheater::profile::icinga::server {
   Icinga2::Object::Service <<| |>>
   Icinga2::Object::Zone <<| |>>
 
+  @firewall { '201 allow access to icinga master':
+    chain => 'INPUT',
+    jump  => 'OPSTHEATER',
+    proto => 'tcp',
+    dport => '5665',
+    tag   => 'opstheater',
+  }
+
 }

--- a/site/opstheater/manifests/profile/icinga/web.pp
+++ b/site/opstheater/manifests/profile/icinga/web.pp
@@ -183,4 +183,22 @@ class opstheater::profile::icinga::web {
     value   => '"UTC"',
   }
 
+  @firewall { '202 allow HTTP access to icinga web':
+    chain   => 'INPUT',
+    action  => 'accept',
+    proto   => 'http',
+    dport   => '80',
+    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag     => 'opstheater',
+  }
+
+  @firewall { '203 allow HTTPS access to icinga web':
+    chain   => 'INPUT',
+    action  => 'accept',
+    proto   => 'http',
+    dport   => '443',
+    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag     => 'opstheater',
+  }
+
 }

--- a/site/opstheater/manifests/profile/icinga/web.pp
+++ b/site/opstheater/manifests/profile/icinga/web.pp
@@ -184,21 +184,21 @@ class opstheater::profile::icinga::web {
   }
 
   @firewall { '202 allow HTTP access to icinga web':
-    chain   => 'INPUT',
-    action  => 'accept',
-    proto   => 'http',
-    dport   => '80',
-    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
-    tag     => 'opstheater',
+    chain  => 'INPUT',
+    action => 'accept',
+    proto  => 'http',
+    dport  => '80',
+    source => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag    => 'opstheater',
   }
 
   @firewall { '203 allow HTTPS access to icinga web':
-    chain   => 'INPUT',
-    action  => 'accept',
-    proto   => 'http',
-    dport   => '443',
-    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
-    tag     => 'opstheater',
+    chain  => 'INPUT',
+    action => 'accept',
+    proto  => 'http',
+    dport  => '443',
+    source => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag    => 'opstheater',
   }
 
 }

--- a/site/opstheater/manifests/profile/kibana.pp
+++ b/site/opstheater/manifests/profile/kibana.pp
@@ -10,11 +10,11 @@ class opstheater::profile::kibana {
   include opstheater::profile::filebeat::kibana
 
   @firewall { '208 allow HTTP access to kibana':
-    chain   => 'INPUT',
-    action  => 'accept',
-    proto   => 'tcp',
-    dport   => '5601',
-    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
-    tag     => 'opstheater',
+    chain  => 'INPUT',
+    action => 'accept',
+    proto  => 'tcp',
+    dport  => '5601',
+    source => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag    => 'opstheater',
   }
 }

--- a/site/opstheater/manifests/profile/kibana.pp
+++ b/site/opstheater/manifests/profile/kibana.pp
@@ -9,4 +9,12 @@ class opstheater::profile::kibana {
 
   include opstheater::profile::filebeat::kibana
 
+  @firewall { '208 allow HTTP access to kibana':
+    chain   => 'INPUT',
+    action  => 'accept',
+    proto   => 'tcp',
+    dport   => '5601',
+    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag     => 'opstheater',
+  }
 }

--- a/site/opstheater/manifests/profile/logstash.pp
+++ b/site/opstheater/manifests/profile/logstash.pp
@@ -43,4 +43,11 @@ class opstheater::profile::logstash {
     create_resources('logstash::plugin', $plugins)
   }
 
+  @firewall { '209 allow access to logstash':
+    chain => 'INPUT',
+    jump  => 'OPSTHEATER',
+    proto => 'tcp',
+    dport => hiera('opstheater::profile::logstash::input_beats_port'),
+  }
+
 }

--- a/site/opstheater/manifests/profile/mysql.pp
+++ b/site/opstheater/manifests/profile/mysql.pp
@@ -30,5 +30,13 @@ class opstheater::profile::mysql {
 
   include opstheater::profile::filebeat::mysql
 
+  @firewall { '210 allow access to mysql':
+    chain => 'INPUT',
+    jump  => 'OPSTHEATER',
+    proto => 'tcp',
+    dport => '3306',
+    tag   => 'opstheater',
+  }
+
 }
 

--- a/site/opstheater/manifests/profile/ssh.pp
+++ b/site/opstheater/manifests/profile/ssh.pp
@@ -1,0 +1,15 @@
+class opstheater::profile::ssh {
+
+  include ::ssh::server
+  include ::ssh::client
+
+  @@firewall { '010 allow SSH access':
+    chain   => 'INPUT',
+    action  => 'allow',
+    proto   => 'tcp',
+    dport   => '22',
+    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag     => 'opstheater',
+  }
+
+}

--- a/site/opstheater/manifests/profile/ssh.pp
+++ b/site/opstheater/manifests/profile/ssh.pp
@@ -4,12 +4,12 @@ class opstheater::profile::ssh {
   include ::ssh::client
 
   @@firewall { '010 allow SSH access':
-    chain   => 'INPUT',
-    action  => 'allow',
-    proto   => 'tcp',
-    dport   => '22',
-    source  => hiera('opstheater::vpn_ip', '0.0.0.0'),
-    tag     => 'opstheater',
+    chain  => 'INPUT',
+    action => 'allow',
+    proto  => 'tcp',
+    dport  => '22',
+    source => hiera('opstheater::vpn_ip', '0.0.0.0'),
+    tag    => 'opstheater',
   }
 
 }


### PR DESCRIPTION
Created a base set of iptables rules for opstheater. It is whitelisted based on the array of IP in hiera. Users have the option to enable/disable the management of iptables itself or purge the rules/chains.